### PR TITLE
Support enums as strings in generated parquet

### DIFF
--- a/parquet-protobuf/pom.xml
+++ b/parquet-protobuf/pom.xml
@@ -27,7 +27,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>parquet-protobuf</artifactId>
-  <version>1.13.0-liftoff0</version>
+  <version>1.13.0-liftoff1</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
@@ -59,6 +59,7 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
   private RecordConsumer recordConsumer;
   private Class<? extends Message> protoMessage;
   private Descriptor descriptor;
+  private boolean enumAsString;
   private FieldIdMapper mapper;
   private MessageWriter messageWriter;
   // Keep protobuf enum value with number in the metadata, so that in read time, a reader can read at least
@@ -66,19 +67,19 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
   private Map<String, Map<String, Integer>> protoEnumBookKeeper = new HashMap<>();
 
   public ProtoWriteSupport() {
-    this(null, null, null);
+    this(null, null, false, null);
   }
 
   public ProtoWriteSupport(FieldIdMapper mapper) {
-    this(null, null, mapper);
+    this(null, null, false, mapper);
   }
 
   public ProtoWriteSupport(Class<? extends Message> protobufClass) {
-    this(protobufClass, null);
+    this(protobufClass, null, false, null);
   }
 
-  public ProtoWriteSupport(Class<? extends Message> protobufClass, FieldIdMapper mapper) {
-    this(protobufClass, null, mapper);
+  public ProtoWriteSupport(Class<? extends Message> protobufClass, boolean enumAsString, FieldIdMapper mapper) {
+    this(protobufClass, null, enumAsString, mapper);
   }
 
   public ProtoWriteSupport(Descriptor descriptor) {
@@ -86,12 +87,13 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
   }
 
   public ProtoWriteSupport(Descriptor descriptor, FieldIdMapper mapper) {
-    this(null, descriptor, mapper);
+    this(null, descriptor, false, mapper);
   }
 
-  private ProtoWriteSupport(Class<? extends Message> protobufClass, Descriptor descriptor, FieldIdMapper mapper) {
+  private ProtoWriteSupport(Class<? extends Message> protobufClass, Descriptor descriptor, boolean enumAsString, FieldIdMapper mapper) {
     this.protoMessage = protobufClass;
     this.descriptor = descriptor;
+    this.enumAsString = enumAsString;
     if (mapper == null) {
       this.mapper = new DefaultFieldIdMapper();
     }
@@ -163,7 +165,7 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
     }
 
     writeSpecsCompliant = configuration.getBoolean(PB_SPECS_COMPLIANT_WRITE, writeSpecsCompliant);
-    MessageType rootSchema = new ProtoSchemaConverter(configuration).convert(descriptor, mapper);
+    MessageType rootSchema = new ProtoSchemaConverter(configuration).convert(descriptor, enumAsString, mapper);
     validatedMapping(descriptor, rootSchema);
 
     this.messageWriter = new MessageWriter(descriptor, rootSchema);

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoSchemaConverterTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoSchemaConverterTest.java
@@ -50,7 +50,7 @@ public class ProtoSchemaConverterTest {
   }
 
   private static void testConversion(Class<? extends Message> pbClass, String parquetSchemaString, ProtoSchemaConverter converter) {
-    MessageType schema = converter.convert(pbClass, new DefaultFieldIdMapper());
+    MessageType schema = converter.convert(pbClass, false, new DefaultFieldIdMapper());
     MessageType expectedMT = MessageTypeParser.parseMessageType(parquetSchemaString);
     assertEquals(expectedMT.toString(), schema.toString());
   }
@@ -522,7 +522,7 @@ public class ProtoSchemaConverterTest {
     long expectedBinaryTreeSize = 4;
     long expectedStructSize = 7;
     for (int i = 0; i < 10; ++i) {
-      MessageType deepSchema = new ProtoSchemaConverter(true, i).convert(Trees.WideTree.class, new DefaultFieldIdMapper());
+      MessageType deepSchema = new ProtoSchemaConverter(true, i).convert(Trees.WideTree.class, false, new DefaultFieldIdMapper());
       // 3, 5, 7, 9, 11, 13, 15, 17, 19, 21
       assertEquals(2 * i + 3, deepSchema.getPaths().size());
 


### PR DESCRIPTION
Add support for treating enum fields as strings when generating parquet files