### PR TITLE
Update to support assigning id to repeated primitive element

### DIFF
--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
@@ -617,6 +617,9 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
   public static class DefaultFieldIdMapper implements FieldIdMapper {
 
     public int mapFieldId(String context, FieldDescriptor fieldDescriptor) {
+      if (fieldDescriptor == null) {
+        return -1;
+      }
       return fieldDescriptor.getNumber();
     }
   }


### PR DESCRIPTION
This PR updates `ProtoSchemaConverter` to assign id to nested primitive element whenever it is needed.